### PR TITLE
Cdh5 1.5 5.4.7

### DIFF
--- a/hbase-indexer-morphlines/src/main/java/com/ngdata/hbaseindexer/morphline/ExtractHBaseCellsBuilder.java
+++ b/hbase-indexer-morphlines/src/main/java/com/ngdata/hbaseindexer/morphline/ExtractHBaseCellsBuilder.java
@@ -117,7 +117,6 @@ public final class ExtractHBaseCellsBuilder implements CommandBuilder {
         private final ByteArrayValueMapper byteArrayMapper;
         private final boolean isIgnoreEmpty;
         
-        // 
         private boolean isEmpty(Object value) {
         	if(value == null || value.toString().length() == 0)
         		return true;


### PR DESCRIPTION
Sometimes some data in hbase are empty, and then  converted into a non-string type to solr, it  will be abnormal, causing an entire row of data can not be synchronized to the solr, i don't want that to happen, so i add an option to  morphlineFile's mappings .it can use as follow

morphlines : [
  {
    id : morphline1
    importCommands : ["org.kitesdk.**", "com.ngdata.**"]
    
    commands : [                    
      {
        extractHBaseCells {
          mappings : [
            {
              inputColumn : "info:name"
              outputField : name_s
              type : string
            }
            
            {
              inputColumn : "f:age"
              outputField : age_i
              type : string
              isIgnoreEmpty : true   #when f:age 's  value is empty, this inputColumn will be skipped, and the default value is false
            }
          ]
        }
      }
    ]
  }
]
